### PR TITLE
Fix dangling pointer warnings

### DIFF
--- a/.github/workflows/swiftpm.yml
+++ b/.github/workflows/swiftpm.yml
@@ -3,13 +3,13 @@ name: SwiftPM
 on:
   push:
     branches: [master]
-    paths: 
+    paths:
       - '.github/workflows/swiftpm.yml'
       - 'Package*'
       - 'Sources/**'
       - 'Tests/**'
   pull_request:
-    paths: 
+    paths:
       - '.github/workflows/swiftpm.yml'
       - 'Package*'
       - 'Sources/**'
@@ -19,8 +19,8 @@ jobs:
   Xcode:
     strategy:
       matrix:
-        xcode_version: ['10','10.1','10.2','10.2.1','10.3','11']
-    runs-on: macOS-10.14
+        xcode_version: ['11.4.1']
+    runs-on: macOS-10.15
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -3,14 +3,14 @@ name: xcodebuild
 on:
   push:
     branches: [master]
-    paths: 
+    paths:
       - '.github/workflows/xcodebuild.yml'
       - 'Base32.xcodeproj/**'
       - 'Sources/**'
       - 'Tests/**'
       - '!Tests/LinuxMain.swift'
   pull_request:
-    paths: 
+    paths:
       - '.github/workflows/xcodebuild.yml'
       - 'Base32.xcodeproj/**'
       - 'Sources/**'
@@ -21,10 +21,10 @@ jobs:
   xcodebuild:
     strategy:
       matrix:
-        xcode_version: ['10','10.1','10.2','10.2.1','10.3','11']
+        xcode_version: ['11.4.1']
         xcode_flags: ['-scheme Base32 -enableCodeCoverage YES -parallel-testing-enabled NO test']
         xcode_flags_for_build_only: ['-scheme Base32 build']
-    runs-on: macOS-10.14
+    runs-on: macOS-10.15
     env:
       DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode_version }}.app
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: watchOS Simulator
         run: xcodebuild ${{ matrix.xcode_flags_for_build_only }} -sdk watchsimulator | xcpretty
         shell: bash
-      - name: Codecov
-        if: matrix.xcode_version == '10.3'
-        run: curl -s https://codecov.io/bash | bash -s -- -t ${{ secrets.CODECOV_TOKEN }}
-        shell: bash
+      # - name: Codecov
+      #   if: matrix.xcode_version == '10.3'
+      #   run: curl -s https://codecov.io/bash | bash -s -- -t ${{ secrets.CODECOV_TOKEN }}
+      #   shell: bash

--- a/Sources/Base32/Base32.swift
+++ b/Sources/Base32/Base32.swift
@@ -44,13 +44,13 @@ public func base32HexEncode(_ data: Data) -> String {
 
 public func base32DecodeToData(_ string: String) -> Data? {
     return base32decode(string, alphabetDecodeTable).flatMap {
-        Data(bytes: UnsafePointer<UInt8>($0), count: $0.count)
+        $0.withUnsafeBufferPointer(Data.init(buffer:))
     }
 }
 
 public func base32HexDecodeToData(_ string: String) -> Data? {
     return base32decode(string, extendedHexAlphabetDecodeTable).flatMap {
-        Data(bytes: UnsafePointer<UInt8>($0), count: $0.count)
+        $0.withUnsafeBufferPointer(Data.init(buffer:))
     }
 }
 
@@ -329,8 +329,8 @@ private func base32decode(_ string: String, _ table: [UInt8]) -> [UInt8]? {
         (data: UnsafeBufferPointer<CChar>) -> [UInt8] in
         var encoded = data.baseAddress!
         
-        let result = Array<UInt8>(repeating: 0, count: dataSize)
-        var decoded = UnsafeMutablePointer<UInt8>(mutating: result)
+        var result = Array<UInt8>(repeating: 0, count: dataSize)
+        var decodedOffset = 0
         
         // decode regular blocks
         var value0, value1, value2, value3, value4, value5, value6, value7: UInt8
@@ -345,14 +345,14 @@ private func base32decode(_ string: String, _ table: [UInt8]) -> [UInt8]? {
             value6 = table[Int(encoded[6])]
             value7 = table[Int(encoded[7])]
             
-            decoded[0] = value0 << 3 | value1 >> 2
-            decoded[1] = value1 << 6 | value2 << 1 | value3 >> 4
-            decoded[2] = value3 << 4 | value4 >> 1
-            decoded[3] = value4 << 7 | value5 << 2 | value6 >> 3
-            decoded[4] = value6 << 5 | value7
+            result[decodedOffset]     = value0 << 3 | value1 >> 2
+            result[decodedOffset + 1] = value1 << 6 | value2 << 1 | value3 >> 4
+            result[decodedOffset + 2] = value3 << 4 | value4 >> 1
+            result[decodedOffset + 3] = value4 << 7 | value5 << 2 | value6 >> 3
+            result[decodedOffset + 4] = value6 << 5 | value7
             
             remainEncodedLength -= 8
-            decoded = decoded.advanced(by: 5)
+            decodedOffset += 5
             encoded = encoded.advanced(by: 8)
         }
         
@@ -377,16 +377,16 @@ private func base32decode(_ string: String, _ table: [UInt8]) -> [UInt8]? {
         }
         switch remainEncodedLength {
         case 7:
-            decoded[3] = value4 << 7 | value5 << 2 | value6 >> 3
+            result[decodedOffset + 3] = value4 << 7 | value5 << 2 | value6 >> 3
             fallthrough
         case 5:
-            decoded[2] = value3 << 4 | value4 >> 1
+            result[decodedOffset + 2] = value3 << 4 | value4 >> 1
             fallthrough
         case 4:
-            decoded[1] = value1 << 6 | value2 << 1 | value3 >> 4
+            result[decodedOffset + 1] = value1 << 6 | value2 << 1 | value3 >> 4
             fallthrough
         case 2:
-            decoded[0] = value0 << 3 | value1 >> 2
+            result[decodedOffset]     = value0 << 3 | value1 >> 2
         default: break
         }
 


### PR DESCRIPTION
Fix #59

It seems Swift is discouraging directly initializing pointers.

1. Instead of using UnsafePointer initializer, use Array's `withUnsafeBufferPointer` factory method and the Data initializer that takes a UnsafeBufferPointer.
2. Instead of using an UnsafeMutablePointer, just use an offset.